### PR TITLE
[Rel #1] index SQLA hybrid properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# misc tools
+.vscode


### PR DESCRIPTION
This allows to specify SQLA `hybrid_property` (proxied and managed
computed field) in `__searchable__` list to be indexed. Computed nature
of this property limits underlying schema field to be `TEXT` and
sorting by it has no sense. See test for example.