### PR TITLE
Special termclass for Whoosh

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,6 +109,24 @@
     search.create_index(Post, delete=True)
     #+END_SRC
 
+*** Custom termclass
+    *only for whoosh backend*
+    #+BEGIN_SRC python
+        from whoosh.query import FuzzyTerm
+        users = User.query.msearch(
+            "test", fields=["name", "username"], limit=20, termclass=FuzzyTerm
+        ).all()
+    #+END_SRC
+
+    or use =__msearch_termclass__= for model
+    #+BEGIN_SRC python
+      from whoosh.query import FuzzyTerm
+      class Post(db.Model):
+          __tablename__ = 'post'
+          __searchable__ = ['title', 'content', 'tag.name']
+          __msearch_termclass__ = FuzzyTerm
+    #+END_SRC
+
 *** Custom Analyzer
     *only for whoosh backend*
     #+BEGIN_SRC python

--- a/flask_msearch/backends.py
+++ b/flask_msearch/backends.py
@@ -103,9 +103,9 @@ class BaseBackend(object):
         _self = self
 
         class Query(q):
-            def msearch(self, query, fields=None, limit=None, or_=False):
+            def msearch(self, query, fields=None, limit=None, or_=False, termclass=None):
                 model = self._mapper_zero().class_
-                return _self.msearch(model, query, fields, limit, or_)
+                return _self.msearch(model, query, fields, limit, or_, termclass)
 
         return Query
 

--- a/flask_msearch/backends.py
+++ b/flask_msearch/backends.py
@@ -103,9 +103,9 @@ class BaseBackend(object):
         _self = self
 
         class Query(q):
-            def msearch(self, query, fields=None, limit=None, or_=False, termclass=None):
+            def msearch(self, query, fields=None, limit=None, or_=False):
                 model = self._mapper_zero().class_
-                return _self.msearch(model, query, fields, limit, or_, termclass)
+                return _self.msearch(model, query, fields, limit, or_)
 
         return Query
 


### PR DESCRIPTION
Allowing the following query:
```python
from whoosh.query import FuzzyTerm
users = User.query.msearch(
    "test", fields=["name", "username"], limit=20, termclass=FuzzyTerm
).all()
```