### PR TITLE
update on backends.py

### DIFF
--- a/flask_msearch/backends.py
+++ b/flask_msearch/backends.py
@@ -16,7 +16,7 @@ import sys
 from flask_sqlalchemy import models_committed
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
-from werkzeug import import_string
+from werkzeug.utils import import_string
 
 from .signal import default_signal
 


### PR DESCRIPTION
Werkzeug moved the import_string() method to the utils folder.