### PR TITLE
fixed RunTime Error caused by create_index in BaseBackend

### DIFF
--- a/flask_msearch/backends.py
+++ b/flask_msearch/backends.py
@@ -158,7 +158,8 @@ class BaseBackend(object):
         if model == '__all__':
             return self.create_all_index(update, delete)
         ix = self.index(model)
-        instances = model.query.enable_eagerloads(False).yield_per(yield_per)
+        with self.app.app_context():
+            instances = model.query.enable_eagerloads(False).yield_per(yield_per)
         for instance in instances:
             self.create_one_index(instance, update, delete, False)
         ix.commit()


### PR DESCRIPTION
This fixed a RunTime Error caused by the create_index() function in the BaseBackend class. When `instances = model.query.enable_eagerloads(False).yield_per(yield_per)` was called, it did not have an app context which Sqlalchemy required causing a RunTime Error.
Traceback Message:
```
Traceback (most recent call last):
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\sqlalchemy\util\_collections.py", line 1020, in __call__
    return self.registry[key]
KeyError: 20444

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\Users\ghub4\Projects_Website\ProjectsWebsite\__init__.py", line 14, in <module>
    from ProjectsWebsite.forms import loginForm
  File ".\ProjectsWebsite\__init__.py", line 83, in <module>
    from ProjectsWebsite.database.models import User, user_datastore
  File ".\ProjectsWebsite\database\models\__init__.py", line 5, in <module>
    from ProjectsWebsite.database.models._models import *
  File ".\ProjectsWebsite\database\models\_models.py", line 175, in <module>
    search.create_index(Article)
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\flask_msearch\backends.py", line 161, in create_index
    instances = model.query.enable_eagerloads(False).yield_per(yield_per)
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\flask_sqlalchemy\__init__.py", line 514, in __get__
    return type.query_class(mapper, session=self.sa.session())
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\sqlalchemy\orm\scoping.py", line 78, in __call__
    return self.registry()
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\sqlalchemy\util\_collections.py", line 1022, in __call__
    return self.registry.setdefault(key, self.createfunc())
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\sqlalchemy\orm\session.py", line 3309, in __call__
    return self.class_(**local_kw)
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\flask_sqlalchemy\__init__.py", line 136, in __init__
    self.app = app = db.get_app()
  File "C:\Users\ghub4\Projects_Website\ProjectEnv\lib\site-packages\flask_sqlalchemy\__init__.py", line 987, in get_app
    raise RuntimeError(
RuntimeError: No application found. Either work inside a view function or push an application context. See http://flask-sqlalchemy.pocoo.org/contexts/.
```
 So I inserted `with self.app.app_context():...` and the module now runs as expected. 